### PR TITLE
fix: support video files larger than max int size in bytes

### DIFF
--- a/src/Skybrud.VideoPicker/Models/Videos/VideoFile.cs
+++ b/src/Skybrud.VideoPicker/Models/Videos/VideoFile.cs
@@ -19,7 +19,7 @@ namespace Skybrud.VideoPicker.Models.Videos {
         public string Type { get; }
 
         [JsonProperty("size", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public long Size { get; }
+        public double Size { get; }
 
         public VideoFile(int width, int height, string url, string type, long size) {
             Width = width;
@@ -34,7 +34,7 @@ namespace Skybrud.VideoPicker.Models.Videos {
             Height = obj.GetInt32("height");
             Url = obj.GetString("url");
             Type = obj.GetString("type");
-            Size = obj.GetInt32("size");
+            Size = obj.GetDouble("size");
         }
 
         public static VideoFile Parse(JObject obj) {

--- a/src/Skybrud.VideoPicker/Models/Videos/VideoFile.cs
+++ b/src/Skybrud.VideoPicker/Models/Videos/VideoFile.cs
@@ -19,7 +19,7 @@ namespace Skybrud.VideoPicker.Models.Videos {
         public string Type { get; }
 
         [JsonProperty("size", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public double Size { get; }
+        public long Size { get; }
 
         public VideoFile(int width, int height, string url, string type, long size) {
             Width = width;
@@ -34,7 +34,7 @@ namespace Skybrud.VideoPicker.Models.Videos {
             Height = obj.GetInt32("height");
             Url = obj.GetString("url");
             Type = obj.GetString("type");
-            Size = obj.GetDouble("size");
+            Size = obj.GetInt64("size");
         }
 
         public static VideoFile Parse(JObject obj) {


### PR DESCRIPTION
Ran into this silly mistake with the new files feature in Vimeo. Was getting the file sizes as an int, which worked fine during testing but broke when the client added a video larger than 2,147,483,647 bytes.

Changed it to double now as Skybrud Essentials doesn't have a GetLong extension method on the jObject 🙂